### PR TITLE
🔧 Chore:jobDetailpageStyled

### DIFF
--- a/src/components/Company/Modal/JobApplyModal.jsx
+++ b/src/components/Company/Modal/JobApplyModal.jsx
@@ -3,11 +3,12 @@ import './JobApplyModal.scss';
 
 const JobApplyModal = ({ onClose, onApply, onEditResume }) => {
   return (
-    <div className="modal-overlay">
-      <div className="modal-box">
+    <div className="modal_overlay">
+      <div className="box">
+        <button className="close_button" onClick={onClose}>×</button>
         <p><strong>지원 시 기업 담당자 이메일로</strong></p>
         <p><strong>이력서가 발송됩니다.</strong></p>
-        <div className="modal-buttons">
+        <div className="buttons">
           <button className="confirm" onClick={onApply}>지원하기</button>
           <button className="cancel" onClick={onEditResume}>이력서 수정하기</button>
         </div>

--- a/src/components/Company/Modal/JobApplyModal.scss
+++ b/src/components/Company/Modal/JobApplyModal.scss
@@ -1,6 +1,6 @@
 @use '@/utils/variables' as *;
 
-.modal-overlay {
+.modal_overlay {
   position: fixed;
   top: 0;
   left: 0;
@@ -13,7 +13,7 @@
   justify-content: center;
 }
 
-.modal-box {
+.box {
   background-color: #fff;
   padding: 30px 40px;
   border-radius: 12px;
@@ -21,23 +21,24 @@
   text-align: center;
   max-width: 400px;
   width: 90%;
+  position: relative;
 }
 
-.modal-box p {
+.box p {
   font-size: 1rem;
   margin-bottom: 10px;
   color: #333;
 }
 
-.modal-buttons {
+.buttons {
   margin-top: 20px;
   display: flex;
   gap: 12px;
   justify-content: center;
 }
 
-.modal-buttons .confirm,
-.modal-buttons .cancel {
+.buttons .confirm,
+.buttons .cancel {
   padding: 10px 20px;
   border: none;
   border-radius: 8px;
@@ -46,20 +47,37 @@
   transition: background-color 0.3s ease;
 }
 
-.modal-buttons .confirm {
+.buttons .confirm {
   background-color: $green;
   color: white;
 }
 
-.modal-buttons .confirm:hover {
+.buttons .confirm:hover {
   background-color: $green;
 }
 
-.modal-buttons .cancel {
+.buttons .cancel {
   background-color: #ddd;
   color: #333;
 }
 
-.modal-buttons .cancel:hover {
+.buttons .cancel:hover {
   background-color: #ccc;
+}
+
+.close_button {
+  position: absolute;
+  top: 12px;
+  right: 16px;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #999;
+  cursor: pointer;
+  transition: color 0.3s ease;
+
+  &:hover {
+    color: #333;
+  }
 }

--- a/src/pages/RecruitmentInfo/JobCard.jsx
+++ b/src/pages/RecruitmentInfo/JobCard.jsx
@@ -37,7 +37,7 @@ const JobCard = ({ job, isBookmarked, toggleBookmark }) => {
           <div className="payment">
             <span className={getPaymentClass(job.payment_method)}>{job.payment_method}</span> {job.salary.toLocaleString()}원
           </div>
-          <div className="description">{job.other_conditions}</div>
+          <div className="description">{job.job_category}</div>
         </div>
         {isBookmarked ? (
           <FaStar className="star_icon filled" onClick={handleBookmarkClick} />

--- a/src/pages/RecruitmentInfo/JobDetail.jsx
+++ b/src/pages/RecruitmentInfo/JobDetail.jsx
@@ -60,6 +60,7 @@ const JobDetail = () => {
     return daysStr;
   };
 
+
   return (
     <div className="jobdetail_container">
       <section className="section">
@@ -95,7 +96,13 @@ const JobDetail = () => {
           <div className="condition_row">
             <div className="condition_label">급여</div>
             <div className="condition_value">
-              <span className="payment_method_badge">{job.payment_method}</span>{job.salary.toLocaleString()}
+              <span className={`payment_method_badge ${
+                job.payment_method === '시급' ? 'payment-hourly' :
+                job.payment_method === '일급' ? 'payment-daily' :
+                job.payment_method === '월급' ? 'payment-monthly' :
+                'payment-default'
+              }`}>{job.payment_method}</span>
+              <span className="salary">{job.salary.toLocaleString()}원</span>
             </div>
           </div>
           <div className="condition_row">
@@ -109,7 +116,12 @@ const JobDetail = () => {
                 ? '협의 가능'
                 : job.is_schedule_based_str
                 ? '일정에 따름'
-                : getWorkDayLabel(job.work_days)}
+                : (
+                  <>
+                    <span className="day_count">주{job.work_days?.split(',').length}일</span>
+                    <span className="day_list">({job.work_days?.split(',').join(', ')})</span>
+                  </>
+                )}
             </div>
           </div>
           <div className="condition_row">
@@ -167,7 +179,7 @@ const JobDetail = () => {
 
       <section className="section">
         <h3>근무지 정보</h3>
-        <div className="address-row" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <div className="address_row" style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
           <div>
             <strong>근무지명:</strong> {job.work_place_name}
           </div>
@@ -183,7 +195,7 @@ const JobDetail = () => {
               <FaRegCopy />
             </button>
           </div>
-          <div className="map-container">
+          <div className="map_container">
             <KakaoMap
               latitude={job.latitude}
               longitude={job.longitude}

--- a/src/pages/RecruitmentInfo/JobDetail.scss
+++ b/src/pages/RecruitmentInfo/JobDetail.scss
@@ -69,9 +69,15 @@
   }
 
   .action {
+    position: sticky;
+    bottom: 0;
+    background: #fff;
+    padding: 12px;
+    border-top: 1px solid #ddd;
     display: flex;
     justify-content: space-between;
-    margin-top: 20px;
+    align-items: center;
+    z-index: 100;
 
     .button {
       flex-grow: 1;
@@ -125,17 +131,54 @@
         .payment_method_badge {
           display: inline-block;
           padding: 2px 8px;
-          border: 1px solid #ff5722;
           color: #ff5722;
           border-radius: 12px;
           font-size: 0.85rem;
           margin-right: 8px;
         }
+        .payment-hourly {
+          color: #009688; // 청록색 (시급)
+          font-weight: bold;
+          border: 1px solid #009688;
+        }
+
+        .payment-daily {
+          color: #ff9800; // 주황색 (일급)
+          font-weight: bold;
+          border: 1px solid #ff9800;
+        }
+
+        .payment-monthly {
+          color: #3f51b5; // 진한 파랑 (월급)
+          font-weight: bold;
+          border: 1px solid #3f51b5;
+        }
+
+        .payment-default {
+          color: #666; // 기본 회색
+          border: 1px solid #666;
+        }
+
+        .day_count {
+          font-weight: 500;
+          margin-right: 4px;
+        }
+
+        .day_list {
+          color: #999;
+          font-size: 0.85rem;
+        }
+
+        .salary {
+          font-size: 1.1rem;
+          font-weight: 700;
+          color: #222;
+        }
       }
     }
   }
 
-  .address-row {
+  .address_row {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -151,7 +194,7 @@
     }
   }
 
-  .map-container {
+  .map_container {
     border: 1px solid #ddd;
     border-radius: 8px;
     padding: 12px;

--- a/src/pages/RecruitmentInfo/JobList.scss
+++ b/src/pages/RecruitmentInfo/JobList.scss
@@ -29,7 +29,12 @@
   margin-top: 2rem;
   gap: 4px;
   list-style: none;
-  padding: 0;
+  padding: 1rem 0;
+  position: sticky;
+  bottom: 0;
+  background-color: #fff;
+  z-index: 10;
+  border-top: 1px solid #ddd;
 
   li {
     display: inline-block;


### PR DESCRIPTION
공고상세페이지 스타일 수정

## 🔥 주요 변경 사항

-받아오는 payment_method 값에 따라 상세페이지 색변경
-상세페이지 지원하기 버튼 하단 고정
-페이지 네이션 하단고정(이상하면 하단고정 삭제할예정)
-지원하기 모달창 닫기 버튼 추가
-근무요일 받아오는 값수 에따라 ex/주1일 (월요일) 식으로 변경 

## ✅ 체크리스트

- [✅] 기능이 정상 동작하나요?
- [✅] 팀 규칙에 맞게 커밋 메시지를 작성했나요?

## 🎯 기타 참고 사항

-
