### PR TITLE
🔧 Chore:serchFilters

### DIFF
--- a/src/apis/RecruitmentApi.js
+++ b/src/apis/RecruitmentApi.js
@@ -15,7 +15,7 @@ export const fetchPublicRecruitments = async (params) => {
     const response = await axios.get(PUBLIC_RECRUITMENT_API_URL, {
       params: {
         recrutPbancTtl: "시니어",         // 공시 제목에 "" 포함된 공고
-        numOfRows: 6,                   // 한 페이지에 가져올 공고 수
+        numOfRows: 8,                   // 한 페이지에 가져올 공고 수
         pageNo: 1,                      // 현재 페이지 번호
         resultType: "json",             // 응답 결과 타입
         ...params,                      // 외부에서 전달된 추가 파라미터들

--- a/src/pages/RecruitmentInfo/JobCard.scss
+++ b/src/pages/RecruitmentInfo/JobCard.scss
@@ -4,7 +4,6 @@
 .job_card_row {
   display: flex;
   align-items: center;
-  padding: 0 1rem 0 0;
   margin: 0;
   min-height: 150px;
   border-top: 1px solid #eee;

--- a/src/pages/RecruitmentInfo/PublicJobList.jsx
+++ b/src/pages/RecruitmentInfo/PublicJobList.jsx
@@ -6,7 +6,6 @@ import './PublicJobList.scss';
 const PublicJobList = () => {
   const [jobs, setJobs] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
-  const jobsPerPage = 6;
 
   useEffect(() => {
     const loadJobs = async () => {

--- a/src/pages/RecruitmentInfo/PublicJobList.scss
+++ b/src/pages/RecruitmentInfo/PublicJobList.scss
@@ -1,7 +1,7 @@
 @use "../../utils/variables" as v;
 .job_section {
     width: 100%;
-    max-width: 1160px;
+    max-width: 100%;
     margin: 0 auto;
     padding: 10px;
 

--- a/src/pages/RecruitmentInfo/SearchFilters.jsx
+++ b/src/pages/RecruitmentInfo/SearchFilters.jsx
@@ -38,6 +38,7 @@ function SearchFilters({
     <div className="Search_container">
       <div className="search_filters">
       <select
+        name="location1"
         value={cityInput}
         onChange={(e) => {
           setCityInput(e.target.value);
@@ -51,7 +52,10 @@ function SearchFilters({
       </select>
 
       {cityInput && (
-        <select value={districtInput} onChange={(e) => setDistrictInput(e.target.value)}>
+        <select
+          name="location2"
+          value={districtInput} onChange={(e) => setDistrictInput(e.target.value)}
+        >
           <option value="">상세 지역 선택</option>
           {(districtsByCity[cityInput] || []).map((gu) => (
             <option key={gu} value={gu}>{gu}</option>

--- a/src/pages/RecruitmentInfo/SearchResults.jsx
+++ b/src/pages/RecruitmentInfo/SearchResults.jsx
@@ -15,17 +15,18 @@ const SearchResults = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const keyword = searchParams.get('keyword') || '';
-  const locationParam = searchParams.get('location') || '';
+  const location1Param = searchParams.get('location1') || '';
+  const location2Param = searchParams.get('location2') || '';
   const jobCategory = searchParams.get('job_category') || '';
   const page = Number(searchParams.get('page')) || 1;
 
   useEffect(() => {
     setSearchQueryState(keyword);
     setCommittedKeyword(keyword);
-    setCityInput(locationParam.split(' ')[0] || '');
-    setDistrictInput(locationParam.split(' ')[1] || '');
+    setCityInput(location1Param || '');
+    setDistrictInput(location2Param || '');
     setJobCategoryInput(jobCategory);
-  }, [keyword, locationParam, jobCategory]);
+  }, [keyword, location1Param,location2Param, jobCategory]);
 
   /**
    * 검색 결과 상태 및 입력값 상태를 관리하는 훅
@@ -44,8 +45,8 @@ const SearchResults = () => {
 
   const [searchQueryState, setSearchQueryState] = useState(keyword);
   const [committedKeyword, setCommittedKeyword] = useState(keyword);
-  const [cityInput, setCityInput] = useState(locationParam.split(' ')[0] || '');
-  const [districtInput, setDistrictInput] = useState(locationParam.split(' ')[1] || '');
+  const [cityInput, setCityInput] = useState(location1Param || '');
+  const [districtInput, setDistrictInput] = useState(location2Param || '');
   const [jobCategoryInput, setJobCategoryInput] = useState(jobCategory);
 
   const [selectedCity, setSelectedCity] = useState(cityInput);
@@ -63,10 +64,10 @@ const SearchResults = () => {
     setSelectedJobCategory(jobCategoryInput);
     setCommittedKeyword(searchQueryState);
 
-    const location = `${cityInput}${districtInput ? ` ${districtInput}` : ''}`;
     const params = new URLSearchParams({
       keyword: searchQueryState,
-      location,
+      location1: cityInput,
+      location2: districtInput,
       job_category: jobCategoryInput,
       page,
     });
@@ -80,10 +81,10 @@ const SearchResults = () => {
   useEffect(() => {
     const fetchResults = async () => {
       try {
-        const location = `${selectedCity}${selectedDistrict ? ` ${selectedDistrict}` : ''}`;
         const rawParams = {
           keyword: committedKeyword,
-          location,
+          location1: selectedCity,
+          location2: selectedDistrict,
           job_category: selectedJobCategory,
           page,
           limit: 10,

--- a/src/pages/RecruitmentInfo/index.jsx
+++ b/src/pages/RecruitmentInfo/index.jsx
@@ -16,13 +16,13 @@ function RecruitmentInfo() {
   const navigate = useNavigate();
 
   const handleSearch = () => {
-    const fullLocation = cityInput && districtInput
-      ? `${cityInput} ${districtInput}`
-      : cityInput || '';
+    const location1 = cityInput;
+    const location2 = districtInput;
 
     const rawParams = {
       keyword: searchQuery,
-      location: fullLocation,
+      location1,
+      location2,
       job_category: jobCategoryInput,
       page: 1,
     };


### PR DESCRIPTION
검색지역필터 수정

## 🔥 주요 변경 사항

-검색필터 기존 location = work_adress(근무지주소) 에서  location1 = region1(시) location2=region2(구) 로 변경
-공공채용 css 수정

## ✅ 체크리스트

- [x] 기능이 정상 동작하나요?
- [x] 팀 규칙에 맞게 커밋 메시지를 작성했나요?

## 🎯 기타 참고 사항

-공공채용 카드 수 6개>>8개 변경
-현재 등록된 공고에 region 1 2 값이 없는 공고들이 있어서 현재 지역필터는 대구,부산 만 되는게 정상
